### PR TITLE
Initializing swipedir in touchEnd function

### DIFF
--- a/src/jquery.mobile-events.js
+++ b/src/jquery.mobile-events.js
@@ -534,6 +534,7 @@
             }
 
             function touchEnd(e) {
+                var swipedir = "";
                 $this.data('callee3', arguments.callee);
                 if (hasSwiped) {
                     // We need to check if the element to which the event was bound contains a data-xthreshold | data-vthreshold:


### PR DESCRIPTION
This appears to be related to Issue #27

In the iOS simulator I get this error:

```
ReferenceError: Can't find variable: swipedir
```

I tracked it down to the `touchEnd` function. It appears `swipedir` is never declared in that function so when you create the `touchData` object `swipedir` could be undefined when you call the `replace` method.
