### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $('#myElement').tap(function(e) {
 ```
 
 **Method chaining:**  
-Chaining has also been preserved, so you can easily use these events in conjuction with other jQuery functions, or attach multiple events in a single, chained LOC:  
+Chaining has also been preserved, so you can easily use these events in conjunction with other jQuery functions, or attach multiple events in a single, chained LOC:  
 ```
 $('#myElement').singletap(function() { 
     console.log('singletap');


### PR DESCRIPTION
@benmajor, I've corrected a typographical error in the documentation of the [jQuery-Touch-Events](https://github.com/benmajor/jQuery-Touch-Events) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.