### PR TITLE
Fixed bug in callback data of firstTap in doubletap event.

### DIFF
--- a/src/1.0.2/jquery.mobile-events.js
+++ b/src/1.0.2/jquery.mobile-events.js
@@ -274,7 +274,7 @@
                 $this = $(thisObject),
                 origTarget,
                 action,
-                firstTap,
+                firstTap = null,
                 origEvent,
 				cooloff,
 				cooling = false;
@@ -288,18 +288,20 @@
                 $this.data('callee1', doubleTapFunc1);
 
                 origEvent = e.originalEvent;
-                firstTap = {
-                    'position': {
-                        'x': (settings.touch_capable) ? origEvent.touches[0].screenX : e.screenX,
-                        'y': (settings.touch_capable) ? origEvent.touches[0].screenY : e.screenY
-                    },
-                    'offset': {
-                        'x': (settings.touch_capable) ? origEvent.touches[0].pageX - origEvent.touches[0].target.offsetLeft : e.offsetX,
-                        'y': (settings.touch_capable) ? origEvent.touches[0].pageY - origEvent.touches[0].target.offsetTop : e.offsetY
-                    },
-                    'time': Date.now(),
-                    'target': e.target
-                };
+                if (!firstTap) {
+                    firstTap = {
+                        'position': {
+                            'x': (settings.touch_capable) ? origEvent.touches[0].screenX : e.screenX,
+                            'y': (settings.touch_capable) ? origEvent.touches[0].screenY : e.screenY
+                        },
+                        'offset': {
+                            'x': (settings.touch_capable) ? origEvent.touches[0].pageX - origEvent.touches[0].target.offsetLeft : e.offsetX,
+                            'y': (settings.touch_capable) ? origEvent.touches[0].pageY - origEvent.touches[0].target.offsetTop : e.offsetY
+                        },
+                        'time': Date.now(),
+                        'target': e.target
+                    };
+                }
 
                 return true;
             }).on(settings.endevent, function doubleTapFunc2(e) {
@@ -342,11 +344,13 @@
                     
                     cooloff = window.setTimeout(function () {
                     	cooling = false;
+                        firstTap = null;
                     }, settings.doubletap_int);
 					
                 } else {
                     $this.data('lastTouch', now);
                     action = window.setTimeout(function () {
+                        firstTap = null;
                         window.clearTimeout(action);
                     }, settings.doubletap_int, [e]);
                 }

--- a/src/1.0.2/jquery.mobile-events.js
+++ b/src/1.0.2/jquery.mobile-events.js
@@ -338,13 +338,13 @@
 
                     if (!cooling) {
                     	triggerCustomEvent(thisObject, 'doubletap', e, touchData);
+                        firstTap = null;
                     }
                     
                     cooling = true;
                     
                     cooloff = window.setTimeout(function () {
                     	cooling = false;
-                        firstTap = null;
                     }, settings.doubletap_int);
 					
                 } else {


### PR DESCRIPTION
firstTap data seems to always be overwritten on the second tap. So position and interval are always wrong.

An other thing, why is the master src file stored in versioned folders? Each time version is increased, the history is reset and it's harder to follow changes.