### PR TITLE
add pointer event at 'tap' event.

### DIFF
--- a/src/jquery.mobile-events.js
+++ b/src/jquery.mobile-events.js
@@ -48,8 +48,10 @@
             touch_capable: ('ontouchstart' in window && !isChromeDesktop),
             orientation_support: ('orientation' in window && 'onorientationchange' in window),
 
-            startevent:  (('ontouchstart' in window && !isChromeDesktop) ? 'touchstart' : 'mousedown'),
-            endevent:    (('ontouchstart' in window && !isChromeDesktop) ? 'touchend' : 'mouseup'),
+            startevent:    (('onpointerdown' in window) ? 'pointerdown' :
+                ('ontouchstart' in window && !isChromeDesktop) ? 'touchstart' : 'mousedown'),
+            endevent:    (('onpointerdown' in window) ? 'pointerup' :
+                ('touchend' in window && !isChromeDesktop) ? 'touchstart' : 'mouseup'),
             moveevent:   (('ontouchstart' in window && !isChromeDesktop) ? 'touchmove' : 'mousemove'),
             tapevent:    ('ontouchstart' in window && !isChromeDesktop) ? 'tap' : 'click',
             scrollevent: ('ontouchstart' in window && !isChromeDesktop) ? 'touchmove' : 'scroll',
@@ -444,7 +446,6 @@
                     y: 0
                 },
                 touches;
-
             $this.on(settings.startevent, function tapFunc1(e) {
                 $this.data('callee1', tapFunc1);
 


### PR DESCRIPTION
Microsoft Edge use the event of 'pointer' better than 'mouse' and 'touch'. So I suggest add a ‘pointer' event in front of 'touch' and 'mouse'. 

Chrome is support too(http://microsoft-news.com/good-news-for-web-developers-google-has-decided-to-support-pointer-events-in-chrome/) .

I think 'pointer' event will be used more frequent than 'mouse' and 'touch' event in future.
http://www.w3.org/TR/pointerevents/