### PR TITLE
Ensure doubletap only fires when detected on the same target

### DIFF
--- a/src/jquery.mobile-events.js
+++ b/src/jquery.mobile-events.js
@@ -288,7 +288,6 @@
                     return false;
                 }
                 $this.data('doubletapped', false);
-                origTarget = e.target;
                 $this.data('callee1', doubleTapFunc1);
 
                 origEvent = e.originalEvent;
@@ -358,6 +357,7 @@
                         window.clearTimeout(action);
                     }, settings.doubletap_int, [e]);
                 }
+                origTarget = e.target;
                 $this.data('lastTouch', now);
             });
         },


### PR DESCRIPTION
This PR fixes [Issue #98 ](https://github.com/benmajor/jQuery-Touch-Events/issues/98).

Was running into this myself and turns out it was a simple fix. I moved setting the original target of a double tap to the end of the Touch Up event listener.

This lets the next tap see the actual original target of the previous tap and ensures double tap is only activated on the same target.